### PR TITLE
Adds launch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,15 @@ To build from source you'll need to create a new workspace, clone and checkout t
 
 
 ## Launch Files
-**Launch files aren't available yet**
 
-In order to include a `cloudwatch_metrics_collector` in your launch file, you should add `<include file="$(find cloudwatch_metrics_collector)/launch/cloudwatch_metrics_collector.launch" />` to your launch file. The launch file uses the following arguments:
+The launch file uses the following arguments:
 
 | Arg Name | Description |
 | --------- | ------------ |
 | node_name | (optional) The name the metrics node should be launched with. If not provided the node will default to "cloudwatch_metrics_collector" |
-| config_file | (optional) A path to a rosparam config file. If provided the launch file will use rosparam to load the configuration into the private namespace of the node. |
+| config_file | (optional) A path to a config file. If provided the launch file will to load the configuration into the private namespace of the node, otherwise defaults to the sample config file. |
 
-An example launch file called `sample_application.launch` is included in this project that gives an example of how you can include this node in your project and provide it with arguments.
+An example launch file called `cloudwatch_metrics_collector_launch.py` is included in this project that gives an example of how you can include this node in your project and provide it with arguments.
 
 
 ## Usage
@@ -101,7 +100,7 @@ An example launch file called `sample_application.launch` is included in this pr
 - Launch the node by itself
   - ``ros2 run cloudwatch_metrics_collector cloudwatch_metrics_collector __params:=`ros2 pkg prefix cloudwatch_metrics_collector`/share/cloudwatch_metrics_collector/config/sample_configuration.yaml``
 - With launch file using parameters in .yaml format (example provided)
-  - ROS: `ros2 launch cloudwatch_metrics_collector sample_application.launch` 
+  - `ros2 launch cloudwatch_metrics_collector cloudwatch_metrics_collector_launch.py` 
 
 ### Send a test metric 
 - `timestamp=$(date +%s); ros2 topic pub /metrics ros_monitoring_msgs/MetricList "{metrics: [{header:{stamp:{sec: ${timestamp}, nanosec: 0}} , metric_name: 'cw_offline_metric', unit: 'Count', value: 1.0, time_stamp: {sec: ${timestamp}, nanosec: 0}, dimensions: [{name: 'example_dimension', value: 'example_value'}]}]}"`
@@ -109,8 +108,6 @@ An example launch file called `sample_application.launch` is included in this pr
 
 ## Configuration File and Parameters
 An example configuration file named `sample_configuration.yaml` is provided that contains a detailed example configuration for the Node.
-
-All parameters to the Node are provided via the parameter server when the node is started. When loading configuration the Node will start looking for each setting inside of its private namespace and then search up the namespace heirarchy to the global namespace for the parameters.
 
 | Parameter Name | Description | Type | Default |
 | ------------- | -----------------------------------------------------------| ------------- | ------------ |

--- a/cloudwatch_metrics_collector/CMakeLists.txt
+++ b/cloudwatch_metrics_collector/CMakeLists.txt
@@ -101,12 +101,10 @@ install(TARGETS ${PROJECT_NAME}_lib
 
 install(DIRECTORY
   config
+  launch
   DESTINATION share/${PROJECT_NAME}
 )
 
-#############
-## Testing ##
-#############
 ament_export_dependencies(aws_common)
 ament_export_dependencies(aws_ros2_common)
 ament_export_dependencies(cloudwatch_metrics_common)

--- a/cloudwatch_metrics_collector/launch/cloudwatch_metrics_collector_launch.py
+++ b/cloudwatch_metrics_collector/launch/cloudwatch_metrics_collector_launch.py
@@ -38,17 +38,17 @@ def generate_launch_description():
     # If this is the RoboMaker Fleet Management environment then add the robot
     # name as a default dimension
     if os.environ[AWS_ROBOMAKER_CAPABILITY] == "AWSRoboMakerFleetManagement" and AWS_ROBOMAKER_ROBOT_NAME in os.environ:
-      aws_default_metric_dimensions = os.environ.get(AWS_ROBOMAKER_ROBOT_NAME)
+      aws_default_metric_dimensions = "RobotName:" + os.environ.get(AWS_ROBOMAKER_ROBOT_NAME)
     # If this is the RoboMaker Simulation envrionment then add the simulation job
     # ID as a default dimension
     if os.environ[AWS_ROBOMAKER_CAPABILITY] == "AWSRoboMakerSimulation" and AWS_ROBOMAKER_SIMULATION_JOB_ID in os.environ:
-       aws_default_metric_dimensions = os.environ.get(AWS_ROBOMAKER_SIMULATION_JOB_ID)
+       aws_default_metric_dimensions = "SimulationJobId:" + os.environ.get(AWS_ROBOMAKER_SIMULATION_JOB_ID)
 
   
       
   parameters=[launch.substitutions.LaunchConfiguration(CONFIG)]
   if aws_robomaker_metric_namespace:
-    parameters.append({"aws_robomaker_metric_namespace": aws_robomaker_metric_namespace})
+    parameters.append({"aws_metrics_namespace": aws_robomaker_metric_namespace})
   if aws_default_metric_dimensions:
     parameters.append({"aws_default_metric_dimensions": aws_default_metric_dimensions})
       

--- a/cloudwatch_metrics_collector/launch/cloudwatch_metrics_collector_launch.py
+++ b/cloudwatch_metrics_collector/launch/cloudwatch_metrics_collector_launch.py
@@ -20,33 +20,35 @@ import launch_ros.actions
 NODE_NAME = "node_name"
 CONFIG = "config"
 
+# AWS RoboMaker Environment Variables
+class RoboMakerEnvVariables():
+  CAPABILITY = "AWS_ROBOMAKER_CAPABILITY"
+  ROBOT_NAME = "AWS_ROBOMAKER_ROBOT_NAME"
+  SIMULATION_JOB_ID = "AWS_ROBOMAKER_SIMULATION_JOB_ID"
+
 def generate_launch_description():
 
   # Default to included config file
   default_config = os.path.join(get_package_share_directory('cloudwatch_metrics_collector'),
     'config', 'sample_configuration.yaml')
 
-  # Envrionment variables provided by AWS RoboMaker
-  AWS_ROBOMAKER_CAPABILITY = "AWS_ROBOMAKER_CAPABILITY"
-  AWS_ROBOMAKER_ROBOT_NAME = "AWS_ROBOMAKER_ROBOT_NAME"
-  AWS_ROBOMAKER_SIMULATION_JOB_ID = "AWS_ROBOMAKER_SIMULATION_JOB_ID"
-
+  
   aws_robomaker_metric_namespace = None
   aws_default_metric_dimensions = None
-  if AWS_ROBOMAKER_CAPABILITY in os.environ:
-    aws_robomaker_metric_namespace = os.environ[AWS_ROBOMAKER_CAPABILITY]
+  if RoboMakerEnvVariables.CAPABILITY in os.environ:
+    aws_robomaker_metric_namespace = os.environ[RoboMakerEnvVariables.CAPABILITY]
     # If this is the RoboMaker Fleet Management environment then add the robot
     # name as a default dimension
-    if os.environ[AWS_ROBOMAKER_CAPABILITY] == "AWSRoboMakerFleetManagement" and AWS_ROBOMAKER_ROBOT_NAME in os.environ:
-      aws_default_metric_dimensions = "RobotName:" + os.environ.get(AWS_ROBOMAKER_ROBOT_NAME)
+    if os.environ[RoboMakerEnvVariables.CAPABILITY] == "AWSRoboMakerFleetManagement" and RoboMakerEnvVariables.ROBOT_NAME in os.environ:
+      aws_default_metric_dimensions = "RobotName:" + os.environ.get(RoboMakerEnvVariables.ROBOT_NAME)
     # If this is the RoboMaker Simulation envrionment then add the simulation job
     # ID as a default dimension
-    if os.environ[AWS_ROBOMAKER_CAPABILITY] == "AWSRoboMakerSimulation" and AWS_ROBOMAKER_SIMULATION_JOB_ID in os.environ:
-       aws_default_metric_dimensions = "SimulationJobId:" + os.environ.get(AWS_ROBOMAKER_SIMULATION_JOB_ID)
+    if os.environ[RoboMakerEnvVariables.CAPABILITY] == "AWSRoboMakerSimulation" and RoboMakerEnvVariables.SIMULATION_JOB_ID in os.environ:
+       aws_default_metric_dimensions = "SimulationJobId:" + os.environ.get(RoboMakerEnvVariables.SIMULATION_JOB_ID)
 
   
       
-  parameters=[launch.substitutions.LaunchConfiguration(CONFIG)]
+  parameters = [launch.substitutions.LaunchConfiguration(CONFIG), ]
   if aws_robomaker_metric_namespace:
     parameters.append({"aws_metrics_namespace": aws_robomaker_metric_namespace})
   if aws_default_metric_dimensions:

--- a/cloudwatch_metrics_collector/launch/cloudwatch_metrics_collector_launch.py
+++ b/cloudwatch_metrics_collector/launch/cloudwatch_metrics_collector_launch.py
@@ -1,0 +1,80 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+import os
+
+from ament_index_python.packages import get_package_share_directory
+import launch
+import launch_ros.actions
+
+# Argument names
+NODE_NAME = "node_name"
+CONFIG = "config"
+
+def generate_launch_description():
+
+  # Default to included config file
+  default_config = os.path.join(get_package_share_directory('cloudwatch_metrics_collector'),
+    'config', 'sample_configuration.yaml')
+
+  # Envrionment variables provided by AWS RoboMaker
+  AWS_ROBOMAKER_CAPABILITY = "AWS_ROBOMAKER_CAPABILITY"
+  AWS_ROBOMAKER_ROBOT_NAME = "AWS_ROBOMAKER_ROBOT_NAME"
+  AWS_ROBOMAKER_SIMULATION_JOB_ID = "AWS_ROBOMAKER_SIMULATION_JOB_ID"
+
+  aws_robomaker_metric_namespace = None
+  aws_default_metric_dimensions = None
+  if AWS_ROBOMAKER_CAPABILITY in os.environ:
+    aws_robomaker_metric_namespace = os.environ[AWS_ROBOMAKER_CAPABILITY]
+    # If this is the RoboMaker Fleet Management environment then add the robot
+    # name as a default dimension
+    if os.environ[AWS_ROBOMAKER_CAPABILITY] == "AWSRoboMakerFleetManagement" and AWS_ROBOMAKER_ROBOT_NAME in os.environ:
+      aws_default_metric_dimensions = os.environ.get(AWS_ROBOMAKER_ROBOT_NAME)
+    # If this is the RoboMaker Simulation envrionment then add the simulation job
+    # ID as a default dimension
+    if os.environ[AWS_ROBOMAKER_CAPABILITY] == "AWSRoboMakerSimulation" and AWS_ROBOMAKER_SIMULATION_JOB_ID in os.environ:
+       aws_default_metric_dimensions = os.environ.get(AWS_ROBOMAKER_SIMULATION_JOB_ID)
+
+  
+      
+  parameters=[launch.substitutions.LaunchConfiguration(CONFIG)]
+  if aws_robomaker_metric_namespace:
+    parameters.append({"aws_robomaker_metric_namespace": aws_robomaker_metric_namespace})
+  if aws_default_metric_dimensions:
+    parameters.append({"aws_default_metric_dimensions": aws_default_metric_dimensions})
+      
+
+
+  ld = launch.LaunchDescription([
+    launch.actions.DeclareLaunchArgument(
+      NODE_NAME,
+      default_value="cloudwatch_metrics_collector",
+    ),
+    launch.actions.DeclareLaunchArgument(
+      CONFIG,
+      default_value=default_config
+    )
+   ])
+  encoder_node = launch_ros.actions.Node(
+    package="cloudwatch_metrics_collector",
+    node_executable="cloudwatch_metrics_collector",
+    node_name=launch.substitutions.LaunchConfiguration(NODE_NAME),
+    parameters=parameters
+  )
+
+  ld.add_action(encoder_node)
+
+  return ld
+
+
+if __name__ == "__main__":
+  generate_launch_description()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a launch file for cloudwatch metrics collector
Updates README with launch file instructions


Testing:

Launched the node and was able to send metrics to cloudwatch
Node picked up default metric namespace and dimensions from environment variables

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
