### PR TITLE
Fix default metric options

### DIFF
--- a/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
@@ -237,31 +237,31 @@ void ReadFileManagerStrategyOptions(
   ReadOption(
     parameter_reader,
     kNodeParamStorageDirectory,
-    Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_directory,
+    Aws::CloudWatchMetrics::kDefaultMetricFileManagerStrategyOptions.storage_directory,
     file_manager_strategy_options.storage_directory);
 
   ReadOption(
     parameter_reader,
     kNodeParamFilePrefix,
-    Aws::FileManagement::kDefaultFileManagerStrategyOptions.file_prefix,
+    Aws::CloudWatchMetrics::kDefaultMetricFileManagerStrategyOptions.file_prefix,
     file_manager_strategy_options.file_prefix);
 
   ReadOption(
     parameter_reader,
     kNodeParamFileExtension,
-    Aws::FileManagement::kDefaultFileManagerStrategyOptions.file_extension,
+    Aws::CloudWatchMetrics::kDefaultMetricFileManagerStrategyOptions.file_extension,
     file_manager_strategy_options.file_extension);
 
   ReadOption(
     parameter_reader,
     kNodeParamMaximumFileSize,
-    Aws::FileManagement::kDefaultFileManagerStrategyOptions.maximum_file_size_in_kb,
+    Aws::CloudWatchMetrics::kDefaultMetricFileManagerStrategyOptions.maximum_file_size_in_kb,
     file_manager_strategy_options.maximum_file_size_in_kb);
 
   ReadOption(
     parameter_reader,
     kNodeParamStorageLimit,
-    Aws::FileManagement::kDefaultFileManagerStrategyOptions.storage_limit_in_kb,
+    Aws::CloudWatchMetrics::kDefaultMetricFileManagerStrategyOptions.storage_limit_in_kb,
     file_manager_strategy_options.storage_limit_in_kb);
 }
 


### PR DESCRIPTION
- Fix bug where default metric storage directory, file prefix etc were being set to the same as logs causing issues when running both cloudwatch logs and metrics at the same time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
