### PR TITLE
Add support for metrics_statistics_msgs

### DIFF
--- a/.rosinstall.master
+++ b/.rosinstall.master
@@ -14,3 +14,7 @@
     uri: https://github.com/aws-robotics/monitoringmessages-ros2.git
     local-name: monitoringmessages-ros2
     version: master
+- git:
+    uri: https://github.com/ros-tooling/system_metrics_collector.git
+    local-name: system_metrics_collector-ros2
+    version: master

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ An example configuration file named `sample_configuration.yaml` is provided that
 | Parameter Name | Description | Type | Default |
 | ------------- | -----------------------------------------------------------| ------------- | ------------ |
 | aws_metrics_namespace | If provided it will set the namespace for all metrics provided by this node to the provided value. If the node is running on AWS RoboMaker then the provided launch file will ignore this parameter in favor of the namespace specified by the AWS RoboMaker ecosystem | *string* | ROS |
-| aws_monitored_metric_topics | An optional list of topics to listen to. If not provided or is empty the node will just listen on the global "metrics" topic. If this list is not empty then the node will not subscribe to the "metrics" topic and will only subscribe to the topics in the list. | *array of strings* | metrics |
+| aws_monitored_metric_topics | An optional list of topics to listen to, where the message the type is `ros_monitoring_msgs/msg/MetricList`. If not provided or is empty the node will just listen on the global "metrics" topic. If this list is not empty then the node will not subscribe to the "metrics" topic and will only subscribe to the topics in the list. | *array of strings* | metrics |
+| system_metrics_topics| An optional list of topics to listen to, where the message the type is `metrics_statistics_msgs/msg/MetricsMessage`. If not provided or is empty the node will just listen on the global "system_metrics" topic. If this list is not empty then the node will not subscribe to the "system_metrics" topic and will only subscribe to the topics in the list. | *array of strings* | system_metrics |
 | storage_directory | The location where all offline metrics will be stored | *string* | ~/.ros/cwmetrics/ |
 | storage_limit | The maximum size of all offline storage files in KB. Once this limit is reached offline logs will start to be deleted oldest first. | *int* | 1048576 |
 | aws_client_configuration | If given the node will load the provided configuration when initializing the client. If a specific configuration setting is not included in the map then it will search up the namespace hierarchy for an 'aws_client_configuration' map that contains the field. In this way, a global configuration can be provided for all AWS nodes with only specific values overridden for a specific Node instance if needed | *map* | |
@@ -131,10 +132,9 @@ Most users won't need to touch these parameters, they are useful if you want fin
 Sends metrics in a ROS system to AWS CloudWatch Metrics service.
 
 #### Subscribed Topics
-- **`Configurable (default="/metrics")`**
+- **Configurable (default: "`/metrics`" and "`/system_metrics`")**
 
-  The node can subscribe to a configurable list of topic names. If no list in provided then it will default to subscribing to a global topic names `/metrics`.<br/>
-  Message Type: `ros_monitoring_msgs/msg/MetricList`
+  The node can subscribe to a configurable list of topic names. If no list is provided then it will default to subscribing to global topic names: `/metrics` (message type: `ros_monitoring_msgs/msg/MetricList`) and `/system_metrics` (message type: `metrics_statistics_msgs/msg/MetricsMessage`).
 
 #### Published Topics
 None

--- a/cloudwatch_metrics_collector/CMakeLists.txt
+++ b/cloudwatch_metrics_collector/CMakeLists.txt
@@ -141,4 +141,14 @@ if(BUILD_TESTING)
   target_link_libraries(test_cloudwatch_metrics_collector
           ${PROJECT_NAME}_lib
           )
+
+  ament_add_gmock(test_metrics_collector
+          test/metrics_collector_test.cpp
+          )
+  target_include_directories(test_metrics_collector PRIVATE
+          ${cloudwatch_metrics_ros2_INCS}
+          )
+  target_link_libraries(test_metrics_collector
+          ${PROJECT_NAME}_lib
+          )
 endif()

--- a/cloudwatch_metrics_collector/CMakeLists.txt
+++ b/cloudwatch_metrics_collector/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(rmw_implementation REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
 find_package(ros_monitoring_msgs REQUIRED)
+find_package(metrics_statistics_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(std_msgs REQUIRED)
 
@@ -52,6 +53,7 @@ set(cloudwatch_metrics_ros2_INCS
   ${rclcpp_INCLUDE_DIRS}
   ${rosgraph_msgs_INCLUDE_DIRS}
   ${ros_monitoring_msgs_INCLUDE_DIRS}
+  ${metrics_statistics_msgs_INCLUDE_DIRS}
   ${std_srvs_INCLUDE_DIRS}
   ${std_msgs_INCLUDE_DIRS}
 )
@@ -68,6 +70,7 @@ set(cloudwatch_metrics_ros2_LIBS
   ${rclcpp_LIBRARIES}
   ${rosgraph_msgs_LIBRARIES}
   ${ros_monitoring_msgs_LIBRARIES}
+  ${metrics_statistics_msgs_LIBRARIES}
   ${std_srvs_LIBRARIES}
   ${std_msgs_LIBRARIES}
 )
@@ -114,6 +117,7 @@ ament_export_dependencies(rmw_implementation)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(rosgraph_msgs)
 ament_export_dependencies(ros_monitoring_msgs)
+ament_export_dependencies(metrics_statistics_msgs)
 ament_export_dependencies(std_srvs)
 ament_export_dependencies(std_msgs)
 

--- a/cloudwatch_metrics_collector/CMakeLists.txt
+++ b/cloudwatch_metrics_collector/CMakeLists.txt
@@ -28,13 +28,13 @@ find_package(aws_ros2_common REQUIRED)
 find_package(cloudwatch_metrics_common REQUIRED)
 find_package(dataflow_lite REQUIRED)
 find_package(file_management REQUIRED)
-find_package(rmw_implementation REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rosgraph_msgs REQUIRED)
-find_package(ros_monitoring_msgs REQUIRED)
 find_package(metrics_statistics_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rmw_implementation REQUIRED)
+find_package(ros_monitoring_msgs REQUIRED)
+find_package(rosgraph_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 
 ###########
 ## Build ##
@@ -49,30 +49,30 @@ set(cloudwatch_metrics_ros2_INCS
   ${cloudwatch_metrics_common_INCLUDE_DIRS}
   ${dataflow_lite_INCLUDE_DIRS}
   ${file_management_INCLUDE_DIRS}
-  ${rmw_implementation_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-  ${rosgraph_msgs_INCLUDE_DIRS}
-  ${ros_monitoring_msgs_INCLUDE_DIRS}
   ${metrics_statistics_msgs_INCLUDE_DIRS}
-  ${std_srvs_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
+  ${rmw_implementation_INCLUDE_DIRS}
+  ${ros_monitoring_msgs_INCLUDE_DIRS}
+  ${rosgraph_msgs_INCLUDE_DIRS}
   ${std_msgs_INCLUDE_DIRS}
+  ${std_srvs_INCLUDE_DIRS}
 )
 
 set(cloudwatch_metrics_ros2_LIBS
   ${ament_cmake_LIBRARIES}
   ${aws_common_LIBRARIES}
   ${aws_ros2_common_LIBRARIES}
-  ${cloudwatch_metrics_common_LIBRARIES}
   ${cloudwatch_metrics_collector_LIBRARIES}
+  ${cloudwatch_metrics_common_LIBRARIES}
   ${dataflow_lite_LIBRARIES}
   ${file_management_LIBRARIES}
-  ${rmw_implementation_LIBRARIES}
-  ${rclcpp_LIBRARIES}
-  ${rosgraph_msgs_LIBRARIES}
-  ${ros_monitoring_msgs_LIBRARIES}
   ${metrics_statistics_msgs_LIBRARIES}
-  ${std_srvs_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${rmw_implementation_LIBRARIES}
+  ${ros_monitoring_msgs_LIBRARIES}
+  ${rosgraph_msgs_LIBRARIES}
   ${std_msgs_LIBRARIES}
+  ${std_srvs_LIBRARIES}
 )
 
 ## Declare a C++ executable
@@ -113,13 +113,13 @@ ament_export_dependencies(aws_ros2_common)
 ament_export_dependencies(cloudwatch_metrics_common)
 ament_export_dependencies(dataflow_lite)
 ament_export_dependencies(file_management)
-ament_export_dependencies(rmw_implementation)
-ament_export_dependencies(rclcpp)
-ament_export_dependencies(rosgraph_msgs)
-ament_export_dependencies(ros_monitoring_msgs)
 ament_export_dependencies(metrics_statistics_msgs)
-ament_export_dependencies(std_srvs)
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(rmw_implementation)
+ament_export_dependencies(ros_monitoring_msgs)
+ament_export_dependencies(rosgraph_msgs)
 ament_export_dependencies(std_msgs)
+ament_export_dependencies(std_srvs)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}_lib ${cloudwatch_metrics_ros2_LIBS})

--- a/cloudwatch_metrics_collector/config/sample_configuration.yaml
+++ b/cloudwatch_metrics_collector/config/sample_configuration.yaml
@@ -6,13 +6,13 @@ cloudwatch_metrics_collector:
     # favor of the namespace specified by the AWS RoboMaker ecosystem
     aws_metrics_namespace: "ros_metrics_collector"
 
-    # An optional list of topics to listen to, where the message the type is ros_monitoring_msgs::msg::MetricList.
+    # An optional list of topics to listen to, where the message the type is ros_monitoring_msgs/msg/MetricList.
     # If not provided or is empty the node will just listen on the global "metrics" topic.
     # If this list is not empty then the node will not subscribe to the "metrics" topic and will only subscribe to the
     # topics in the list.
     # aws_monitored_metric_topics: ["metrics"]
 
-    # An optional list of topics to listen to, where the message the type is metrics_statistics_msgs::msg::MetricsMessage.
+    # An optional list of topics to listen to, where the message the type is metrics_statistics_msgs/msg/MetricsMessage.
     # If not provided or is empty the node will just listen on the global "system_metrics" topic.
     # If this list is not empty then the node will not subscribe to the "system_metrics" topic and will only subscribe to the
     # topics in the list.

--- a/cloudwatch_metrics_collector/config/sample_configuration.yaml
+++ b/cloudwatch_metrics_collector/config/sample_configuration.yaml
@@ -5,66 +5,73 @@ cloudwatch_metrics_collector:
     # the provided value. If the node is running on AWS RoboMaker, then the provided launch file will ignore this parameter in
     # favor of the namespace specified by the AWS RoboMaker ecosystem
     aws_metrics_namespace: "ros_metrics_collector"
-    
-    # An optional list of topics to listen to. If not provided or is empty the node will just listen on the global "metrics"
-    # topic. If this list is not empty then the node will not subscribe to the "metrics" topic and will only subscribe to the
+
+    # An optional list of topics to listen to, where the message the type is ros_monitoring_msgs::msg::MetricList.
+    # If not provided or is empty the node will just listen on the global "metrics" topic.
+    # If this list is not empty then the node will not subscribe to the "metrics" topic and will only subscribe to the
     # topics in the list.
-    #aws_monitored_metric_topics: ["metrics"]
-    
+    # aws_monitored_metric_topics: ["metrics"]
+
+    # An optional list of topics to listen to, where the message the type is metrics_statistics_msgs::msg::MetricsMessage.
+    # If not provided or is empty the node will just listen on the global "system_metrics" topic.
+    # If this list is not empty then the node will not subscribe to the "system_metrics" topic and will only subscribe to the
+    # topics in the list.
+    # system_metrics_topics: ["system_metrics"]
+
     # The absolute path to a folder that all offline metric files will be stored in
     storage_directory: "~/.ros/cwmetrics/"
-    
+
     # The maximum size of all files in offline storage in KB
     storage_limit: 1048576
-    
+
     # This is the AWS Client Configuration used by the AWS service client in the Node. If given the node will load the
     # provided configuration when initializing the client.
     aws_client_configuration:
         # Specifies where you want the client to communicate. Examples include us-east-1 or us-west-1. You must ensure that
         # the service you want to use has an endpoint in the region you configure.
         region: "us-west-2"
-    
+
         # Built in the constructor and pulls information from your operating system. Do not alter the user agent.
         #user_agent: ""
-    
+
         # Use this to override the http endpoint used to talk to a service. If you set this, you must also set authenticationRegion.
         #endpoint_override: ""
-    
+
         # These settings allow you to configure a proxy for all communication with AWS. Examples of when this functionality
         # might be useful include debugging in conjunction with the Burp suite, or using a proxy to connect to the Internet.
         #proxy_host: ""
         #proxy_port: 0
         #proxy_user_name: ""
         #proxy_password: ""
-    
+
         # Enables you to tell the HTTP client where to find your SSL certificate trust store (for example, a directory
         # prepared with OpenSSL's c_rehash utility). You shouldn't need to do this unless you are using symlinks in your
         # environment. This has no effect on Windows or OS X.
         #ca_path: ""
         #ca_file: ""
-    
+
         # Values that determine the length of time, in milliseconds, to wait before timing out a request. You can increase
         # this value if you need to transfer large files, such as in Amazon S3 or Amazon CloudFront.
         request_timeout_ms: 2000
         connect_timeout_ms: 2000
         no_retry_strategy: true
-    
+
         # The maximum number of allowed connections to a single server for your HTTP communications. The default value is 25.
         # You can set this value as high as you can support the bandwidth. We recommend a value around 25.
         #max_connections: 25
-    
+
         # Use dual stack endpoint in the endpoint calculation. You must ensure that the service you want to use supports ipv6 in the region you select.
         #use_dual_stack: false
-    
+
         # Enable adjustment for clock skew
         #enable_clock_skew_adjustment: true
-    
+
         # If set to true the http stack will follow redirect codes
         #follow_redirects: false
-    
+
         # Specifies whether to enable SSL certificate verification. If necessary, you can disable SSL certificate verification by setting verifySSL to false.
         #verify_SSL: true
-    
+
     # This is the storage resolution level for presenting metrics in CloudWatch.
     # Valid values are 1 and 60. Setting this to 1 specifies this metric as a
     # high-resolution metric, so that CloudWatch stores the metric with sub-minute

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector.hpp
@@ -42,7 +42,7 @@ public:
   ~MetricsCollector() = default;
 
   /**
-   * Accept input metric message to be batched for publishing.
+   * Accept input ros_monitoring_msgs::msg::MetricList message to be batched for publishing.
    *
    * @param metric_list_msg
    * @return the number of metrics successfully batched
@@ -50,7 +50,7 @@ public:
   int RecordMetrics(ros_monitoring_msgs::msg::MetricList::UniquePtr metric_list_msg);
 
   /**
-   * Accept input metric message to be batched for publishing.
+   * Accept input metrics_statistics_msgs::msg::MetricsMessage message to be batched for publishing.
    *
    * @param msg
    * @return the number of metrics successfully batched
@@ -80,7 +80,28 @@ public:
                   const Aws::Client::ClientConfiguration & config,
                   const Aws::SDKOptions & sdk_options,
                   const Aws::CloudWatchMetrics::CloudWatchOptions & cloudwatch_options,
-                  const std::vector<Aws::CloudWatchMetrics::Utils::TopicInfo> & topics,
+                  const std::vector<std::string> & topics,
+                  std::shared_ptr<MetricServiceFactory> metric_service_factory = std::make_shared<MetricServiceFactory>());
+
+  /**
+   * Initialize the MetricsCollector with parameters read from the config file.
+   *
+   * @param metric_namespace
+   * @param default_dimensions
+   * @param storage_resolution
+   * @param config
+   * @param sdk_options
+   * @param topics
+   * @param metric_service_factory
+   */
+  void Initialize(std::string metric_namespace,
+                  std::map<std::string, std::string> & default_dimensions,
+                  int storage_resolution,
+                  rclcpp::Node::SharedPtr node,
+                  const Aws::Client::ClientConfiguration & config,
+                  const Aws::SDKOptions & sdk_options,
+                  const Aws::CloudWatchMetrics::CloudWatchOptions & cloudwatch_options,
+                  const std::vector<TopicInfo> & topics,
                   std::shared_ptr<MetricServiceFactory> metric_service_factory = std::make_shared<MetricServiceFactory>());
 
   void SubscribeAllTopics();

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector.hpp
@@ -74,7 +74,7 @@ public:
    * @param metric_service_factory
    */
   void Initialize(std::string metric_namespace,
-                  std::map<std::string, std::string> & default_dimensions,
+                  const std::map<std::string, std::string> & default_dimensions,
                   int storage_resolution,
                   rclcpp::Node::SharedPtr node,
                   const Aws::Client::ClientConfiguration & config,
@@ -95,7 +95,7 @@ public:
    * @param metric_service_factory
    */
   void Initialize(std::string metric_namespace,
-                  std::map<std::string, std::string> & default_dimensions,
+                  const std::map<std::string, std::string> & default_dimensions,
                   int storage_resolution,
                   rclcpp::Node::SharedPtr node,
                   const Aws::Client::ClientConfiguration & config,
@@ -116,7 +116,8 @@ public:
    * @param response output response
    * @return true if the request was handled successfully, false otherwise
    */
-  bool checkIfOnline(std::shared_ptr<std_srvs::srv::Trigger::Request> request, std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  bool checkIfOnline(std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                     std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
   /**
    * Gets the timestamp for the input metric message as milliseconds since epoch

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector.hpp
@@ -15,20 +15,20 @@
 
 #pragma once
 
-#include <aws_common/sdk_utils/logging/aws_log_system.h>
-#include <rclcpp/rclcpp.hpp>
-#include <builtin_interfaces/msg/time.hpp>
-#include <ros_monitoring_msgs/msg/metric_list.hpp>
-#include <metrics_statistics_msgs/msg/metrics_message.hpp>
-#include <std_srvs/srv/trigger.hpp>
-#include <std_srvs/srv/empty.hpp>
+#include <map>
+#include <string>
 
+#include <aws_common/sdk_utils/logging/aws_log_system.h>
+#include <builtin_interfaces/msg/time.hpp>
+#include <metrics_statistics_msgs/msg/metrics_message.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <ros_monitoring_msgs/msg/metric_list.hpp>
+#include <std_srvs/srv/empty.hpp>
+#include <std_srvs/srv/trigger.hpp>
+
+#include <cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp>
 #include <cloudwatch_metrics_common/metric_service.hpp>
 #include <cloudwatch_metrics_common/metric_service_factory.hpp>
-#include <cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp>
-
-#include <string>
-#include <map>
 
 namespace Aws {
 namespace CloudWatchMetrics {
@@ -70,6 +70,7 @@ public:
    * @param storage_resolution
    * @param config
    * @param sdk_options
+   * @param topics
    * @param metric_service_factory
    */
   void Initialize(std::string metric_namespace,

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
@@ -15,12 +15,16 @@
 
 #pragma once
 
-#include <cloudwatch_metrics_common/cloudwatch_options.h>
+#include <array>
+#include <iostream>
+#include <string>
+#include <unordered_set>
+
+#include <rclcpp/rclcpp.hpp>
+
 #include <aws_common/sdk_utils/aws_error.h>
 #include <aws_common/sdk_utils/parameter_reader.h>
-#include <rclcpp/rclcpp.hpp>
-#include <unordered_set>
-#include <iostream>
+#include <cloudwatch_metrics_common/cloudwatch_options.h>
 
 using namespace Aws::Client;
 
@@ -28,11 +32,12 @@ namespace Aws {
 namespace CloudWatchMetrics {
 namespace Utils {
 
-const std::string kNodeParamMonitorTopicsListKey("aws_monitored_metric_topics");
-const std::string kNodeParamMetricNamespaceKey = "aws_metrics_namespace";
-const std::string kNodeParamDefaultMetricDimensionsKey  = "aws_default_metric_dimensions";
-const std::string kNodeName = "cloudwatch_metrics_collector";
-const char kNodeParamPublishFrequencyKey[] = "publish_frequency";
+constexpr char kNodeParamMonitorTopicsListKey[] = "aws_monitored_metric_topics";
+constexpr char kNodeParamMonitorTopicTypesListKey[] = "aws_monitored_metric_topic_types";
+constexpr char kNodeParamMetricNamespaceKey[] = "aws_metrics_namespace";
+constexpr char kNodeParamDefaultMetricDimensionsKey[]  = "aws_default_metric_dimensions";
+constexpr char kNodeName[] = "cloudwatch_metrics_collector";
+constexpr char kNodeParamPublishFrequencyKey[] = "publish_frequency";
 
 /** Configuration params for Aws::DataFlow::UploaderOptions **/
 constexpr char kNodeParamBatchMaxQueueSize[] = "batch_max_queue_size";
@@ -48,13 +53,28 @@ constexpr char kNodeParamMaximumFileSize[] = "maximum_file_size";
 constexpr char kNodeParamStorageDirectory[] = "storage_directory";
 constexpr char kNodeParamStorageLimit[] = "storage_limit";
 
+enum class TopicType
+{
+  ROS_MONITORING_MSGS = 1,
+  METRICS_STATISTICS_MSGS = 2
+};
+
+struct TopicInfo
+{
+  std::string topic_name;
+  TopicType topic_type;
+};
+
 constexpr int kNodeSubQueueSize = 100;
 constexpr int kNodePublishFrequencyDefaultValue = 10;
-const int kNodeMetricServiceTimeSec = 1;
-const std::string kNodeDefaultMetricNamespace = "ROS";
-const std::string kNodeDefaulMetricsTopic = "metrics";
+constexpr int kNodeMetricServiceTimeSec = 1;
+constexpr char kNodeDefaultMetricNamespace[] = "ROS";
+const std::array<TopicInfo, 2> kNodeDefaultMetricsTopics = {{
+  {"metrics", TopicType::ROS_MONITORING_MSGS},
+  {"system_metrics", TopicType::METRICS_STATISTICS_MSGS}
+}};
 constexpr int kNodeDefaultMetricDatumStorageResolution = 60;
-const std::string kNodeParamMetricDatumStorageResolutionKey = "storage_resolution";
+constexpr char kNodeParamMetricDatumStorageResolutionKey[] = "storage_resolution";
 const std::set<int> kNodeParamMetricDatumStorageResolutionValidValues = {1, 60};
 
 
@@ -109,7 +129,7 @@ void ReadStorageResolution(
  */
 void ReadTopics(
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
-  std::vector<std::string> & topics);
+  std::vector<TopicInfo> & topics);
 
 /**
  * Fetch the options related to cloudwatch uploading and offline file mangement

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
@@ -55,8 +55,8 @@ constexpr char kNodeParamStorageLimit[] = "storage_limit";
 
 enum class TopicType
 {
-  ROS_MONITORING_MSGS = 1,
-  METRICS_STATISTICS_MSGS = 2
+  ROS_MONITORING_MSGS,
+  METRICS_STATISTICS_MSGS
 };
 
 struct TopicInfo

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
@@ -32,7 +32,7 @@ namespace Aws {
 namespace CloudWatchMetrics {
 namespace Utils {
 
-constexpr char kNodeParamMonitorTopicsListKey[] = "aws_monitored_metric_topics";
+constexpr char kNodeParamMonitoringTopicsListKey[] = "aws_monitored_metric_topics";
 constexpr char kNodeParamMetricsTopicsListKey[] = "system_metrics_topics";
 constexpr char kNodeParamMetricNamespaceKey[] = "aws_metrics_namespace";
 constexpr char kNodeParamDefaultMetricDimensionsKey[]  = "aws_default_metric_dimensions";

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
@@ -33,7 +33,7 @@ namespace CloudWatchMetrics {
 namespace Utils {
 
 constexpr char kNodeParamMonitorTopicsListKey[] = "aws_monitored_metric_topics";
-constexpr char kNodeParamMonitorTopicTypesListKey[] = "aws_monitored_metric_topic_types";
+constexpr char kNodeParamMetricsTopicsListKey[] = "system_metrics_topics";
 constexpr char kNodeParamMetricNamespaceKey[] = "aws_metrics_namespace";
 constexpr char kNodeParamDefaultMetricDimensionsKey[]  = "aws_default_metric_dimensions";
 constexpr char kNodeName[] = "cloudwatch_metrics_collector";
@@ -69,10 +69,10 @@ constexpr int kNodeSubQueueSize = 100;
 constexpr int kNodePublishFrequencyDefaultValue = 10;
 constexpr int kNodeMetricServiceTimeSec = 1;
 constexpr char kNodeDefaultMetricNamespace[] = "ROS";
-const std::array<TopicInfo, 2> kNodeDefaultMetricsTopics = {{
-  {"metrics", TopicType::ROS_MONITORING_MSGS},
-  {"system_metrics", TopicType::METRICS_STATISTICS_MSGS}
-}};
+const std::map<TopicType, std::string> kNodeDefaultMetricsTopics = {
+  {TopicType::ROS_MONITORING_MSGS, "metrics"},
+  {TopicType::METRICS_STATISTICS_MSGS, "system_metrics"}
+};
 constexpr int kNodeDefaultMetricDatumStorageResolution = 60;
 constexpr char kNodeParamMetricDatumStorageResolutionKey[] = "storage_resolution";
 const std::set<int> kNodeParamMetricDatumStorageResolutionValidValues = {1, 60};

--- a/cloudwatch_metrics_collector/package.xml
+++ b/cloudwatch_metrics_collector/package.xml
@@ -19,6 +19,7 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw_implementation</build_depend>
   <build_depend>ros_monitoring_msgs</build_depend>
+  <build_depend>metrics_statistics_msgs</build_depend>
   
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch</exec_depend>
@@ -30,6 +31,7 @@
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>ros_monitoring_msgs</exec_depend>
+  <exec_depend>metrics_statistics_msgs</exec_depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <export>

--- a/cloudwatch_metrics_collector/package.xml
+++ b/cloudwatch_metrics_collector/package.xml
@@ -14,24 +14,24 @@
   <build_depend>aws_common</build_depend>
   <build_depend>aws_ros2_common</build_depend>
   <build_depend>cloudwatch_metrics_common</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
+  <build_depend>metrics_statistics_msgs</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw_implementation</build_depend>
   <build_depend>ros_monitoring_msgs</build_depend>
-  <build_depend>metrics_statistics_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   
-  <exec_depend>launch_ros</exec_depend>
-  <exec_depend>launch</exec_depend>
   <exec_depend>aws_common</exec_depend>
   <exec_depend>aws_ros2_common</exec_depend>
   <exec_depend>cloudwatch_metrics_common</exec_depend>
-  <exec_depend>std_srvs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>metrics_statistics_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>ros_monitoring_msgs</exec_depend>
-  <exec_depend>metrics_statistics_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <export>

--- a/cloudwatch_metrics_collector/src/main.cpp
+++ b/cloudwatch_metrics_collector/src/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char * argv[])
   std::vector<std::shared_ptr<rclcpp::Subscription<ros_monitoring_msgs::msg::MetricData>>> subscriptions;
 
   // initialize SDK logging
-  Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>(kNodeName.c_str(),
+  Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>(kNodeName,
     Aws::Utils::Logging::LogLevel::Trace, node));
 
   //-----------Start Read Configuration Parameters---------------------
@@ -76,7 +76,7 @@ int main(int argc, char * argv[])
   std::string metric_namespace;
   Aws::String dimensions_param;
   std::map<std::string, std::string> default_metric_dims;
-  std::vector<std::string> topics;
+  std::vector<Aws::CloudWatchMetrics::Utils::TopicInfo> topics;
 
   // Load the storage resolution
   int storage_resolution = kNodeDefaultMetricDatumStorageResolution;

--- a/cloudwatch_metrics_collector/src/metrics_collector.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector.cpp
@@ -204,11 +204,8 @@ int MetricsCollector::RecordMetrics(
     ++batched_count;
   }
 
-  dimensions.clear();
-  dimensions["metric_type"] = msg->metrics_source + " stddev";
-
   MetricObject stddev_object(
-    msg->measurement_source_name,
+    msg->measurement_source_name + "_stddev",
     msg->unit,
     GetMetricDataEpochMillis(msg->window_start),
     stddev,

--- a/cloudwatch_metrics_collector/src/metrics_collector.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector.cpp
@@ -54,7 +54,7 @@ namespace CloudWatchMetrics {
 namespace Utils {
 
 void MetricsCollector::Initialize(std::string metric_namespace,
-                         std::map<std::string, std::string> & default_dimensions,
+                         const std::map<std::string, std::string> & default_dimensions,
                          int storage_resolution,
                          rclcpp::Node::SharedPtr node,
                          const Aws::Client::ClientConfiguration & config,
@@ -72,7 +72,7 @@ void MetricsCollector::Initialize(std::string metric_namespace,
 }
 
 void MetricsCollector::Initialize(std::string metric_namespace,
-                         std::map<std::string, std::string> & default_dimensions,
+                         const std::map<std::string, std::string> & default_dimensions,
                          int storage_resolution,
                          rclcpp::Node::SharedPtr node,
                          const Aws::Client::ClientConfiguration & config,
@@ -273,5 +273,3 @@ bool MetricsCollector::checkIfOnline(std::shared_ptr<std_srvs::srv::Trigger::Req
 }  // namespace Utils
 }  // namespace CloudWatchMetrics
 }  // namespace Aws
-
-

--- a/cloudwatch_metrics_collector/src/metrics_collector.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector.cpp
@@ -85,8 +85,8 @@ void MetricsCollector::SubscribeAllTopics()
     } else if (it->topic_type == TopicType::METRICS_STATISTICS_MSGS) {
       sub = node_->create_subscription<metrics_statistics_msgs::msg::MetricsMessage>(
               it->topic_name, kNodeSubQueueSize,
-              [this](metrics_statistics_msgs::msg::MetricsMessage::UniquePtr /*msg*/) -> void {
-                // this->RecordMetrics(std::move(msg));
+              [this](metrics_statistics_msgs::msg::MetricsMessage::UniquePtr msg) -> void {
+                this->RecordMetrics(std::move(msg));
               });
     }
     subscriptions_.push_back(std::move(sub));

--- a/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
@@ -165,15 +165,15 @@ void ReadTopics(
         std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
         std::vector<TopicInfo> & topics) {
 
-  std::vector<std::string> monitor_topic_names;
-  parameter_reader->ReadParam(ParameterPath(kNodeParamMonitorTopicsListKey), monitor_topic_names);
-  if (monitor_topic_names.empty()) {
+  std::vector<std::string> monitoring_topic_names;
+  parameter_reader->ReadParam(ParameterPath(kNodeParamMonitoringTopicsListKey), monitoring_topic_names);
+  if (monitoring_topic_names.empty()) {
     AWS_LOGSTREAM_INFO(__func__, "Monitoring topics list not defined or empty. Listening on topic: "
                        << kNodeDefaultMetricsTopics.at(TopicType::ROS_MONITORING_MSGS));
     topics.push_back(TopicInfo{kNodeDefaultMetricsTopics.at(TopicType::ROS_MONITORING_MSGS),
                                TopicType::ROS_MONITORING_MSGS});
   } else {
-    for (auto & topic_name : monitor_topic_names) {
+    for (auto & topic_name : monitoring_topic_names) {
       topics.push_back(TopicInfo{std::move(topic_name), TopicType::ROS_MONITORING_MSGS});
     }
   }

--- a/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
@@ -17,10 +17,10 @@
 #include <unordered_set>
 
 #include <aws/core/utils/logging/LogMacros.h>
-#include <rclcpp/rclcpp.hpp>
-
 #include <aws_common/sdk_utils/aws_error.h>
 #include <aws_common/sdk_utils/parameter_reader.h>
+#include <rclcpp/rclcpp.hpp>
+
 #include <cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp>
 #include <cloudwatch_metrics_common/cloudwatch_options.h>
 

--- a/cloudwatch_metrics_collector/test/cloudwatch_metrics_collector_test.cpp
+++ b/cloudwatch_metrics_collector/test/cloudwatch_metrics_collector_test.cpp
@@ -226,7 +226,7 @@ TEST_F(CloudwatchMetricsCollectorFixture, timerCallsMetricManagerService)
   .Times(::testing::AtLeast(num_msgs))
   .WillRepeatedly(::testing::Return(true));
 
-  ros_monitoring_msgs::msg::MetricData metric_data = BasicMonitoringData();
+  ros_monitoring_msgs::msg::MetricData metric_data = EmptyMonitoringData();
   SendMonitoringMessages(num_msgs, metric_data);
   for (int i = 0; i < num_msgs; i++) {
     rclcpp::spin_some(node_handle);
@@ -273,7 +273,7 @@ TEST_F(CloudwatchMetricsCollectorFixture, metricsRecordedNoDimension)
     .WillOnce(::testing::Return(true));
   }
 
-  ros_monitoring_msgs::msg::MetricData metric_data = BasicMonitoringData();
+  ros_monitoring_msgs::msg::MetricData metric_data = EmptyMonitoringData();
   SendMonitoringMessages(num_msgs, metric_data);
   rclcpp::spin_some(node_handle);
 }
@@ -308,7 +308,7 @@ TEST_F(CloudwatchMetricsCollectorFixture, metricRecordedWithDimension)
 
   Initialize(expected_dim, topics);
 
-  ros_monitoring_msgs::msg::MetricData metric_data = BasicMonitoringData();
+  ros_monitoring_msgs::msg::MetricData metric_data = EmptyMonitoringData();
   ros_monitoring_msgs::msg::MetricDimension metric_dimension = ros_monitoring_msgs::msg::MetricDimension();
   metric_dimension.name = metric_dimension_name;
   metric_dimension.value = metric_dimension_value;
@@ -350,7 +350,7 @@ TEST_F(CloudwatchMetricsCollectorFixture, metricRecordedWithDefaultDimensions)
   default_metric_dims.emplace(metric_dimension_name, metric_dimension_value);
   Initialize(default_metric_dims, topics);
 
-  ros_monitoring_msgs::msg::MetricData metric_data = BasicMonitoringData();
+  ros_monitoring_msgs::msg::MetricData metric_data = EmptyMonitoringData();
 
   SendMonitoringMessages(num_msgs, metric_data);
   rclcpp::spin_some(node_handle);
@@ -379,7 +379,7 @@ TEST_F(CloudwatchMetricsCollectorFixture, customTopicsListened)
   .WillOnce(::testing::Return(true));
 
   ros_monitoring_msgs::msg::MetricList metric_list_msg = ros_monitoring_msgs::msg::MetricList();
-  ros_monitoring_msgs::msg::MetricData metric_data = BasicMonitoringData();
+  ros_monitoring_msgs::msg::MetricData metric_data = EmptyMonitoringData();
 
   rclcpp::Publisher<ros_monitoring_msgs::msg::MetricList>::SharedPtr metrics_pub0 =
     node_handle->create_publisher<ros_monitoring_msgs::msg::MetricList>(topics[0].topic_name, 1);

--- a/cloudwatch_metrics_collector/test/metrics_collector_test.cpp
+++ b/cloudwatch_metrics_collector/test/metrics_collector_test.cpp
@@ -179,20 +179,17 @@ TEST_F(MetricsCollectorFixture, RecordMetricsMessages)
   ASSERT_EQ(2 * metric_data.size(), metric_objs.size());
 
   for (size_t i = 0; i < metric_data.size(); ++i) {
-    EXPECT_EQ(metric_data[i].measurement_source_name, metric_objs[2*i].metric_name);
-    EXPECT_EQ(metric_data[i].measurement_source_name+"_stddev", metric_objs[2*i+1].metric_name);
+    EXPECT_EQ(metric_data[i].measurement_source_name, metric_objs[2*i].dimensions.at("Measurement Source"));
+    EXPECT_EQ(metric_data[i].measurement_source_name, metric_objs[2*i+1].dimensions.at("Measurement Source"));
 
-    EXPECT_EQ(metric_data[i].metrics_source, metric_objs[2*i].dimensions.at("metric_type"));
-    EXPECT_EQ(metric_data[i].metrics_source, metric_objs[2*i+1].dimensions.at("metric_type"));
+    EXPECT_EQ(metric_data[i].metrics_source, metric_objs[2*i].metric_name);
+    EXPECT_EQ(metric_data[i].metrics_source+"_stddev", metric_objs[2*i+1].metric_name);
 
-    EXPECT_EQ(metric_data[i].unit, metric_objs[2*i].dimensions.at("metric_unit"));
-    EXPECT_EQ(metric_data[i].unit, metric_objs[2*i+1].dimensions.at("metric_unit"));
+    EXPECT_EQ(metric_data[i].unit, metric_objs[2*i].unit);
+    EXPECT_EQ(metric_data[i].unit, metric_objs[2*i+1].unit);
 
     EXPECT_EQ(MetricsCollector::GetMetricDataEpochMillis(metric_data[i].window_start), metric_objs[2*i].timestamp);
     EXPECT_EQ(MetricsCollector::GetMetricDataEpochMillis(metric_data[i].window_start), metric_objs[2*i+1].timestamp);
-
-    EXPECT_EQ(MetricsCollector::GetMetricDataEpochMillis(metric_data[i].window_stop)
-      - MetricsCollector::GetMetricDataEpochMillis(metric_data[i].window_start), metric_objs[2*i].value);
 
     for (const auto & statistic : metric_data[i].statistics) {
       if (statistic.data_type == StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE) {

--- a/cloudwatch_metrics_collector/test/metrics_collector_test.cpp
+++ b/cloudwatch_metrics_collector/test/metrics_collector_test.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <limits>
+#include <map>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include <metrics_statistics_msgs/msg/metrics_message.hpp>
+#include <ros_monitoring_msgs/msg/metric_data.hpp>
+
+#include <cloudwatch_metrics_common/metric_service.hpp>
+#include <cloudwatch_metrics_common/metric_service_factory.hpp>
+#include <cloudwatch_metrics_collector/metrics_collector.hpp>
+
+#include "test_common.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace Aws::CloudWatchMetrics::Utils;
+using namespace Aws::CloudWatchMetrics;
+using metrics_statistics_msgs::msg::StatisticDataType;
+
+class MetricServiceMock : public MetricService
+{
+public:
+  MetricServiceMock(const std::string & metrics_namespace) : MetricService(
+    std::make_shared<MetricPublisher>(metrics_namespace, Aws::Client::ClientConfiguration()),
+    std::make_shared<MetricBatcher>()) {}
+
+  bool batchData(const MetricObject & data_to_batch)
+  {
+    metric_objects_.push_back(data_to_batch);
+    return true;
+  }
+
+  const std::vector<MetricObject> & GetMetricObjects()
+  {
+    return metric_objects_;
+  }
+
+private:
+  std::vector<MetricObject> metric_objects_;
+};
+
+class MetricServiceFactoryMock : public MetricServiceFactory
+{
+public:
+  MetricServiceFactoryMock(std::shared_ptr<MetricService> metric_service)
+    : mock_metric_service_(std::move(metric_service)) {}
+
+  std::shared_ptr<MetricService> createMetricService(
+    const std::string & /*metrics_namespace*/,
+    const Aws::Client::ClientConfiguration & /*client_config*/,
+    const Aws::SDKOptions & /*sdk_options*/,
+    const CloudWatchOptions & /*cloudwatch_option*/)
+  {
+    return mock_metric_service_;
+  }
+
+private:
+  std::shared_ptr<MetricService> mock_metric_service_;
+};
+
+class MetricsCollectorFixture : public ::testing::Test
+{
+  void SetUp()
+  {
+    mock_metric_service_ = std::make_shared<MetricServiceMock>(kTestMetricsNamespace);
+    mock_metric_service_factory_ = std::make_shared<MetricServiceFactoryMock>(mock_metric_service_);
+
+    metrics_collector_.Initialize(
+      kTestMetricsNamespace,
+      default_dimensions_,
+      60,
+      nullptr,
+      client_config_,
+      sdk_options_,
+      cloudwatch_options_,
+      topics_,
+      mock_metric_service_factory_);
+  }
+
+protected:
+  static constexpr char kTestMetricsNamespace[] = "test_namespace";
+
+  Aws::Client::ClientConfiguration client_config_;
+  Aws::SDKOptions sdk_options_;
+  Aws::CloudWatchMetrics::CloudWatchOptions cloudwatch_options_;
+  std::vector<TopicInfo> topics_;
+
+  std::map<std::string, std::string> default_dimensions_;
+  std::shared_ptr<MetricServiceMock> mock_metric_service_;
+  std::shared_ptr<MetricServiceFactoryMock> mock_metric_service_factory_;
+  MetricsCollector metrics_collector_;
+};
+
+constexpr char MetricsCollectorFixture::kTestMetricsNamespace[];
+
+TEST_F(MetricsCollectorFixture, RecordRosMonitoringMessages)
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dist(0.0, 100.0);
+
+  std::array<ros_monitoring_msgs::msg::MetricData, 2> metric_data = {{
+    BasicMonitoringData(),
+    BasicMonitoringData()
+  }};
+  for (auto & data : metric_data) {
+    data.value = dist(gen);
+  }
+
+  auto metric_list = std::make_unique<ros_monitoring_msgs::msg::MetricList>();
+  for (const auto & data : metric_data) {
+    metric_list->metrics.push_back(data);
+  }
+
+  size_t num_batched = metrics_collector_.RecordMetrics(std::move(metric_list));
+  ASSERT_EQ(metric_data.size(), num_batched);
+
+  const auto & metric_objs = mock_metric_service_->GetMetricObjects();
+  ASSERT_EQ(metric_data.size(), metric_objs.size());
+
+  for (size_t i = 0; i < metric_data.size(); ++i) {
+    EXPECT_EQ(metric_data[i].metric_name, metric_objs[i].metric_name);
+    EXPECT_EQ(metric_data[i].unit, metric_objs[i].unit);
+    if (std::isnan(metric_data[i].value)) {
+      EXPECT_TRUE(std::isnan(metric_objs[i].value));
+    } else {
+      EXPECT_DOUBLE_EQ(metric_data[i].value, metric_objs[i].value);
+    }
+    EXPECT_EQ(MetricsCollector::GetMetricDataEpochMillis(metric_data[i].time_stamp), metric_objs[i].timestamp);
+
+    std::map<std::string, std::string> dimensions;
+    for (const auto & dimension : metric_data[i].dimensions) {
+      dimensions[dimension.name] = dimension.value;
+    }
+    EXPECT_EQ(dimensions, metric_objs[i].dimensions);
+  }
+}
+
+TEST_F(MetricsCollectorFixture, RecordMetricsMessages)
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> dist(0.0, 100.0);
+
+  std::array<metrics_statistics_msgs::msg::MetricsMessage, 2> metric_data = {{
+    BasicMetricsData(),
+    BasicMetricsData()
+  }};
+  for (auto & metric : metric_data) {
+    for (auto & statistic : metric.statistics) {
+      statistic.data = dist(gen);
+    }
+  }
+
+  for (const auto & data : metric_data) {
+    auto msg = std::make_unique<metrics_statistics_msgs::msg::MetricsMessage>(data);
+    int num_batched = metrics_collector_.RecordMetrics(std::move(msg));
+    ASSERT_EQ(2, num_batched);
+  }
+
+  const auto & metric_objs = mock_metric_service_->GetMetricObjects();
+  ASSERT_EQ(2 * metric_data.size(), metric_objs.size());
+
+  for (size_t i = 0; i < metric_data.size(); ++i) {
+    EXPECT_EQ(metric_data[i].measurement_source_name, metric_objs[2*i].metric_name);
+    EXPECT_EQ(metric_data[i].measurement_source_name+"_stddev", metric_objs[2*i+1].metric_name);
+
+    EXPECT_EQ(metric_data[i].metrics_source, metric_objs[2*i].dimensions.at("metric_type"));
+    EXPECT_EQ(metric_data[i].metrics_source, metric_objs[2*i+1].dimensions.at("metric_type"));
+
+    EXPECT_EQ(metric_data[i].unit, metric_objs[2*i].dimensions.at("metric_unit"));
+    EXPECT_EQ(metric_data[i].unit, metric_objs[2*i+1].dimensions.at("metric_unit"));
+
+    EXPECT_EQ(MetricsCollector::GetMetricDataEpochMillis(metric_data[i].window_start), metric_objs[2*i].timestamp);
+    EXPECT_EQ(MetricsCollector::GetMetricDataEpochMillis(metric_data[i].window_start), metric_objs[2*i+1].timestamp);
+
+    EXPECT_EQ(MetricsCollector::GetMetricDataEpochMillis(metric_data[i].window_stop)
+      - MetricsCollector::GetMetricDataEpochMillis(metric_data[i].window_start), metric_objs[2*i].value);
+
+    for (const auto & statistic : metric_data[i].statistics) {
+      if (statistic.data_type == StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE) {
+        if (std::isnan(statistic.data)) {
+          EXPECT_TRUE(std::isnan(metric_objs[2*i].statistic_values.at(StatisticValuesType::SUM))
+            || std::isnan(metric_objs[2*i].statistic_values.at(StatisticValuesType::SAMPLE_COUNT)));
+        } else {
+          EXPECT_DOUBLE_EQ(statistic.data,
+            metric_objs[2*i].statistic_values.at(StatisticValuesType::SUM)
+            / metric_objs[2*i].statistic_values.at(StatisticValuesType::SAMPLE_COUNT));
+        }
+      } else if (statistic.data_type == StatisticDataType::STATISTICS_DATA_TYPE_MAXIMUM) {
+        if (std::isnan(statistic.data)) {
+          EXPECT_TRUE(std::isnan(metric_objs[2*i].statistic_values.at(StatisticValuesType::MAXIMUM)));
+        } else {
+          EXPECT_DOUBLE_EQ(statistic.data, metric_objs[2*i].statistic_values.at(StatisticValuesType::MAXIMUM));
+        }
+      } else if (statistic.data_type == StatisticDataType::STATISTICS_DATA_TYPE_MINIMUM) {
+        if (std::isnan(statistic.data)) {
+          EXPECT_TRUE(std::isnan(metric_objs[2*i].statistic_values.at(StatisticValuesType::MINIMUM)));
+        } else {
+          EXPECT_DOUBLE_EQ(statistic.data, metric_objs[2*i].statistic_values.at(StatisticValuesType::MINIMUM));
+        }
+      } else if (statistic.data_type == StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT) {
+        if (std::isnan(statistic.data)) {
+          EXPECT_TRUE(std::isnan(metric_objs[2*i].statistic_values.at(StatisticValuesType::SAMPLE_COUNT)));
+        } else {
+          EXPECT_DOUBLE_EQ(statistic.data, metric_objs[2*i].statistic_values.at(StatisticValuesType::SAMPLE_COUNT));
+        }
+      } else if (statistic.data_type == StatisticDataType::STATISTICS_DATA_TYPE_STDDEV) {
+        if (std::isnan(statistic.data)) {
+          EXPECT_TRUE(std::isnan(metric_objs[2*i+1].value));
+        } else {
+          EXPECT_DOUBLE_EQ(statistic.data, metric_objs[2*i+1].value);
+        }
+      }
+    }
+    EXPECT_TRUE(metric_objs[2*i+1].statistic_values.empty());
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/cloudwatch_metrics_collector/test/test_common.hpp
+++ b/cloudwatch_metrics_collector/test/test_common.hpp
@@ -39,7 +39,7 @@ void chrono_time_point_to_builtin_interfaces_time(
   timestamp.nanosec = nanosecs.count();
 }
 
-inline ros_monitoring_msgs::msg::MetricData BasicMonitoringData()
+inline ros_monitoring_msgs::msg::MetricData EmptyMonitoringData()
 {
   ros_monitoring_msgs::msg::MetricData data = ros_monitoring_msgs::msg::MetricData();
   data.metric_name = kMetricName;
@@ -49,7 +49,7 @@ inline ros_monitoring_msgs::msg::MetricData BasicMonitoringData()
   return data;
 }
 
-inline metrics_statistics_msgs::msg::MetricsMessage BasicMetricsData()
+inline metrics_statistics_msgs::msg::MetricsMessage EmptyMetricsData()
 {
   metrics_statistics_msgs::msg::MetricsMessage data = metrics_statistics_msgs::msg::MetricsMessage();
   data.measurement_source_name = kMeasurementSource;

--- a/cloudwatch_metrics_collector/test/test_common.hpp
+++ b/cloudwatch_metrics_collector/test/test_common.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <limits>
+
+#include <builtin_interfaces/msg/time.hpp>
+#include <metrics_statistics_msgs/msg/metrics_message.hpp>
+#include <metrics_statistics_msgs/msg/statistic_data_type.hpp>
+#include <ros_monitoring_msgs/msg/metric_data.hpp>
+
+constexpr char kMeasurementSource[] = "CWMetricsNodeTest";
+constexpr char kMetricName[] = "CWMetricsNodeTestMetric";
+constexpr char kMetricUnit[] = "sec";
+
+template<typename chrono_time_point>
+void chrono_time_point_to_builtin_interfaces_time(
+  const chrono_time_point & timepoint,
+  builtin_interfaces::msg::Time & timestamp)
+{
+  auto secs = std::chrono::time_point_cast<std::chrono::seconds>(timepoint);
+  auto nanosecs = std::chrono::time_point_cast<std::chrono::nanoseconds>(timepoint)
+                  - std::chrono::time_point_cast<std::chrono::nanoseconds>(secs);
+  timestamp.sec = secs.time_since_epoch().count();
+  timestamp.nanosec = nanosecs.count();
+}
+
+inline ros_monitoring_msgs::msg::MetricData BasicMonitoringData()
+{
+  ros_monitoring_msgs::msg::MetricData data = ros_monitoring_msgs::msg::MetricData();
+  data.metric_name = kMetricName;
+  data.unit = kMetricUnit;
+  data.value = std::numeric_limits<decltype(data.value)>::quiet_NaN();
+  chrono_time_point_to_builtin_interfaces_time(std::chrono::system_clock::now(), data.time_stamp);
+  return data;
+}
+
+inline metrics_statistics_msgs::msg::MetricsMessage BasicMetricsData()
+{
+  metrics_statistics_msgs::msg::MetricsMessage data = metrics_statistics_msgs::msg::MetricsMessage();
+  data.measurement_source_name = kMeasurementSource;
+  data.metrics_source = kMetricName;
+  data.unit = kMetricUnit;
+  chrono_time_point_to_builtin_interfaces_time(std::chrono::system_clock::now(), data.window_start);
+  chrono_time_point_to_builtin_interfaces_time(std::chrono::system_clock::now(), data.window_stop);
+
+  using metrics_statistics_msgs::msg::StatisticDataType;
+  using StatisticValueType = decltype(metrics_statistics_msgs::msg::StatisticDataPoint::data);
+  data.statistics.reserve(5);
+
+  data.statistics.emplace_back();
+  data.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_AVERAGE;
+  data.statistics.back().data = std::numeric_limits<StatisticValueType>::quiet_NaN();
+
+  data.statistics.emplace_back();
+  data.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_MAXIMUM;
+  data.statistics.back().data = std::numeric_limits<StatisticValueType>::quiet_NaN();
+
+  data.statistics.emplace_back();
+  data.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_MINIMUM;
+  data.statistics.back().data = std::numeric_limits<StatisticValueType>::quiet_NaN();
+
+  data.statistics.emplace_back();
+  data.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_SAMPLE_COUNT;
+  data.statistics.back().data = std::numeric_limits<StatisticValueType>::quiet_NaN();
+
+  data.statistics.emplace_back();
+  data.statistics.back().data_type = StatisticDataType::STATISTICS_DATA_TYPE_STDDEV;
+  data.statistics.back().data = std::numeric_limits<StatisticValueType>::quiet_NaN();
+
+  return data;
+}


### PR DESCRIPTION
*Issue #:* https://github.com/ros-security/aws-roadmap/issues/157

*Description of changes:*
Add support for `metrics_statistic_msgs`, which is the output type of `system_metrics_collector`.

This change depends on https://github.com/ros-tooling/system_metrics_collector/pull/85 and https://github.com/aws-robotics/cloudwatch-common/pull/48.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
